### PR TITLE
Tnation/travis ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+language: bash
+services: docker
+
+env:
+  - TERRAFORM_VERSION=0.9.1
+  - TERRAFORM_VERSION=0.9.6
+  - TERRAFORM_VERSION=0.9.8
+  - TERRAFORM_VERSION=latest
+
+script:
+  - ./scripts/cibuild
+
+deploy:
+  - provider: script
+    script: "scripts/cipublish"
+    on:
+      repo: azavea/docker-terraform
+      branch: master

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,9 @@
+FROM hashicorp/terraform:%%TERRAFORM_VERSION%%
+MAINTAINER Azavea <systems@azavea.com>
+
+RUN \
+    apk add --no-cache \
+        bash \
+        python3 \
+        py-pip \
+    && pip install awscli

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Azavea, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # docker-terraform
-A base Docker image for Terraform
+
+This repository contains a templated `Dockerfile` for image variants designed to run deployments using the AWS CLI and `terraform`.
+
+## Usage
+
+### Template Variables
+
+- `TERRAFORM_VERSION` - Terraform version
+
+### Testing
+
+An example of how to use `cibuild` to build and test an image:
+
+```bash
+$ CI=1 TERRAFORM_VERSION=9.8 ./scripts/cibuild
+```

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Build container images from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+
+        sed -e "s/%%TERRAFORM_VERSION%%/${TERRAFORM_VERSION}/" \
+            "Dockerfile.template" > Dockerfile
+
+        docker \
+            build -t "quay.io/azavea/terraform:${TERRAFORM_VERSION}" .
+
+
+        ./scripts/test
+
+        docker images
+    fi
+fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Publish container images built from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker \
+            login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
+
+        docker \
+            push "quay.io/azavea/terraform:${TERRAFORM_VERSION}"
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+set -u
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Test container images built from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+
+        docker run --rm -it \
+         "quay.io/azavea/terraform:${TERRAFORM_VERSION}" --help \
+         | grep "Usage: terraform"
+
+        docker run --rm -it --entrypoint pip \
+         "quay.io/azavea/terraform:${TERRAFORM_VERSION}" show awscli \
+         | grep "awscli"
+
+    fi
+fi


### PR DESCRIPTION
# Overview

Adds a configuration to build and deploy containers using Travis CI.
 
## Notable changes:
-  Add `cibuild`, `cipublish`, and `test` STRTA
- Add `.travis.yml` that calls STRTA to build containers in CI
    - Builds terraform `0.9.1`, `0.9.6`, `0.9.8`, and `latest` (so that we can test new versions of TF as they come out) 

# Testing
- See [Travis CI status](https://travis-ci.org/azavea/docker-terraform/builds/258275748)
- https://quay.io/repository/azavea/terraform?tab=tags