### PR TITLE
Add installation of zip and make utilities

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,8 @@ MAINTAINER Azavea <systems@azavea.com>
 RUN \
     apk add --no-cache \
         bash \
+        make \
         python3 \
         py-pip \
+        zip \
     && pip install awscli


### PR DESCRIPTION
Install the `zip` and `make` command-line utilities within the context of this container image.

This is useful for when we need to create a function source code archive for Amazon Lambda.

---

**Testing**

```bash
$ CI=1 TERRAFORM_VERSION=0.10.8 ./scripts/cibuild                                   
+ set -u
+ '[' ./scripts/cibuild = ./scripts/cibuild ']'
+ '[' '' = --help ']'
+ sed -e s/%%TERRAFORM_VERSION%%/0.10.8/ Dockerfile.template
+ docker build -t quay.io/azavea/terraform:0.10.8 .
Sending build context to Docker daemon  97.28kB
Step 1/3 : FROM hashicorp/terraform:0.10.8
 ---> 678f45ae8570
Step 2/3 : MAINTAINER Azavea <systems@azavea.com>
 ---> Using cache
 ---> d59aaa702151
Step 3/3 : RUN     apk add --no-cache         bash         python3         py-pip         zip     && pip install awscli
 ---> Using cache
 ---> 5b0105a5804c
Successfully built 5b0105a5804c
Successfully tagged quay.io/azavea/terraform:0.10.8
+ ./scripts/test
+ set -u
+ '[' ./scripts/test = ./scripts/test ']'
+ '[' '' = --help ']'
+ docker run --rm -it quay.io/azavea/terraform:0.10.8 --help
+ grep 'Usage: terraform'
Usage: terraform [--version] [--help] <command> [args]
+ docker run --rm -it --entrypoint pip quay.io/azavea/terraform:0.10.8 show awscli
+ grep awscli
Name: awscli
+ docker images
REPOSITORY                                  TAG                 IMAGE ID            CREATED              SIZE
quay.io/azavea/terraform                    0.10.8              5b0105a5804c        About a minute ago   242MB
$ docker run --rm --entrypoint /bin/bash quay.io/azavea/terraform:0.10.8 -c 'zip -v'
Copyright (c) 1990-2008 Info-ZIP - Type 'zip "-L"' for software license.
This is Zip 3.0 (July 5th 2008), by Info-ZIP.
Currently maintained by E. Gordon.  Please send bug reports to
the authors using the web page at www.info-zip.org; see README for details.

Latest sources and executables are at ftp://ftp.info-zip.org/pub/infozip,
as of above date; see http://www.info-zip.org/ for other sites.

Compiled with gcc 6.2.1 20160822 for Unix (Linux ELF) on Oct 25 2016.

Zip special compilation options:
        USE_EF_UT_TIME       (store Universal Time)
        SYMLINK_SUPPORT      (symbolic links supported)
        LARGE_FILE_SUPPORT   (can read and write large files on file system)
        ZIP64_SUPPORT        (use Zip64 to store large files in archives)
        UNICODE_SUPPORT      (store and read UTF-8 Unicode paths)
        STORE_UNIX_UIDs_GIDs (store UID/GID sizes/values using new extra field)
        UIDGID_NOT_16BIT     (old Unix 16-bit UID/GID extra field not used)
        [encryption, version 2.91 of 05 Jan 2007] (modified for Zip 3)

Encryption notice:
        The encryption code of this program is not copyrighted and is
        put in the public domain.  It was originally written in Europe
        and, to the best of our knowledge, can be freely distributed
        in both source and object forms from any country, including
        the USA under License Exception TSU of the U.S. Export
        Administration Regulations (section 740.13(e)) of 6 June 2002.

Zip environment options:
             ZIP:  [none]
          ZIPOPT:  [none]
```