### PR TITLE
Add jq to container image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,7 @@ MAINTAINER Azavea <systems@azavea.com>
 RUN \
     apk add --no-cache \
         bash \
+        jq \
         make \
         python3 \
         py-pip \

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository contains a templated `Dockerfile` for image variants designed to
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 TERRAFORM_VERSION=9.8 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=0.10.8 ./scripts/cibuild
 ```


### PR DESCRIPTION
This PR installs `jq` in the container, which is useful for parsing AWS CLI output. Additionally, fix the README example to use a more recent Terraform version.

# Testing
- Ensure Travis build passes.