### PR TITLE
Add Terraform 0.12.13 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TERRAFORM_VERSION=0.11.7
   - TERRAFORM_VERSION=0.11.11
   - TERRAFORM_VERSION=0.12.2
+  - TERRAFORM_VERSION=0.12.13
 
 script:
   - ./scripts/cibuild

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository contains a templated `Dockerfile` for image variants designed to
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 TERRAFORM_VERSION=0.10.8 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=0.12.13 ./scripts/cibuild
 ```


### PR DESCRIPTION
Builds container images for Terraform 0.12.13.

---
**Testing**

```bash
$ CI=1 TERRAFORM_VERSION=0.12.13 ./scripts/cibuild

...

+ ./scripts/test
+ set -u
+ '[' ./scripts/test = ./scripts/test ']'
+ '[' '' = --help ']'
+ docker run --rm -it quay.io/azavea/terraform:0.12.13 --version
Terraform v0.12.13
+ docker run --rm -it --entrypoint aws quay.io/azavea/terraform:0.12.13 --version
aws-cli/1.16.274 Python/2.7.16 Linux/5.3.8-arch1-1 botocore/1.13.10
+ docker images
REPOSITORY                                                                  TAG                     IMAGE ID            CREATED             SIZE
quay.io/azavea/terraform                                                    0.12.13                 d39b6bcb6429        4 seconds ago       241MB
hashicorp/terraform                                                         0.12.13                 5d5c9faad78b        5 days ago          79.6MB
```