### PR TITLE
Use pip3 to install awscli

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,5 @@ RUN \
         jq \
         make \
         python3 \
-        py-pip \
         zip \
-    && pip install awscli
+    && pip3 install awscli

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docker-terraform
+# docker-terraform [![Travis (.org) branch](https://img.shields.io/travis/azavea/docker-terraform/master)](https://travis-ci.org/azavea/docker-terraform) [![Docker Repository on Quay](https://quay.io/repository/azavea/terraform/status "Docker Repository on Quay")](https://quay.io/repository/azavea/terraform)
 
 This repository contains a templated `Dockerfile` for image variants designed to run deployments using the AWS CLI and `terraform`.
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -10,7 +10,7 @@ set -u
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Build container images from templates.
 "
 }
@@ -21,11 +21,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
 
         sed -e "s/%%TERRAFORM_VERSION%%/${TERRAFORM_VERSION}/" \
-            "Dockerfile.template" > Dockerfile
+            "Dockerfile.template" >Dockerfile
 
         docker \
             build -t "quay.io/azavea/terraform:${TERRAFORM_VERSION}" .
-
 
         ./scripts/test
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -5,7 +5,7 @@ set -u
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Publish container images built from templates.
 "
 }

--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ set -u
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Test container images built from templates.
 "
 }
@@ -19,11 +19,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-
         docker run --rm -it \
-         "quay.io/azavea/terraform:${TERRAFORM_VERSION}" --version
+            "quay.io/azavea/terraform:${TERRAFORM_VERSION}" --version
 
         docker run --rm -it --entrypoint aws \
-         "quay.io/azavea/terraform:${TERRAFORM_VERSION}" --version
+            "quay.io/azavea/terraform:${TERRAFORM_VERSION}" --version
     fi
 fi


### PR DESCRIPTION
This PR incorporates a change we made for the gfw-iac-workshop [Terraform image](https://github.com/azavea/gfw-iac-workshop/blob/master/Dockerfile) where we install the `awscli` with Python 3 pip.

While we're in here, there is a second commit that runs shfmt and adds sugar to the README.

This was in my backlog of low priority items I am clearing out.

---

**Testing**

See Travis CI build: https://travis-ci.org/azavea/docker-terraform/builds/621757835