### PR TITLE
Add curl to container image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,4 +7,5 @@ RUN \
         make \
         python3 \
         zip \
+        curl \
     && pip3 install awscli


### PR DESCRIPTION
This PR installs `curl` in the container, which is useful for notifying Rollbar of deploys. It appears that `curl` is no longer included in the 0.12.x base images.