### PR TITLE
Add Terraform 0.12.29 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ language: bash
 services: docker
 
 env:
-  - TERRAFORM_VERSION=0.10.4
-  - TERRAFORM_VERSION=0.10.8
-  - TERRAFORM_VERSION=0.11.7
   - TERRAFORM_VERSION=0.11.11
   - TERRAFORM_VERSION=0.12.2
   - TERRAFORM_VERSION=0.12.13
+  - TERRAFORM_VERSION=0.12.29
 
 script:
   - ./scripts/cibuild

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,6 +6,7 @@ RUN \
         jq \
         make \
         python3 \
+        py-pip \
         zip \
         curl \
     && pip3 install awscli

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Azavea, Inc.
+   Copyright 2020 Azavea, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository contains a templated `Dockerfile` for image variants designed to
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 TERRAFORM_VERSION=0.12.13 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=0.12.29 ./scripts/cibuild
 ```


### PR DESCRIPTION
Adds Terraform 0.12.29 to the build matrix. In addition, remove 0.10.x and 0.11.7 from the build matrix.

(Terraform 0.12.29 was released later today. This PR was created in the morning, when 0.12.28 was the most recent version of Terraform available.)

---

**Testing**

```console
$ CI=1 TERRAFORM_VERSION=0.12.28 ./scripts/cibuild

. . .

+ ./scripts/test
+ set -u
+ '[' ./scripts/test = ./scripts/test ']'
+ '[' '' = --help ']'
+ docker run --rm -it quay.io/azavea/terraform:0.12.28 --version
Terraform v0.12.28
+ docker run --rm -it --entrypoint aws quay.io/azavea/terraform:0.12.28 --version
aws-cli/1.18.102 Python/3.8.5 Linux/4.19.76-linuxkit botocore/1.17.25
+ docker images
REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
quay.io/azavea/terraform   0.12.28             e00af475e11a        8 seconds ago       224MB
<none>                     <none>              d0adaf0c14ac        2 minutes ago       224MB
<none>                     <none>              4c764d06b405        2 minutes ago       224MB
<none>                     <none>              19ad1a18a396        3 minutes ago       224MB
<none>                     <none>              a7f7f72364a0        5 minutes ago       224MB
hashicorp/terraform        0.12.28             99282bc47725        2 weeks ago         98MB
```