### PR TITLE
Add Terraform 0.11.14 to build matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: ["0.11.11", "0.12.2", "0.12.13", "0.12.29", "0.13.5"]
+        terraform_version: ["0.11.11", "0.11.14", "0.12.2", "0.12.13", "0.12.29", "0.13.5"]
     env:
       DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}


### PR DESCRIPTION
Builds container images for Terraform 0.11.14.

Connects https://github.com/azavea/raster-foundry-platform/issues/1042

---
**Testing**

```bash
$ CI=1 TERRAFORM_VERSION=0.11.14 ./scripts/cibuild
. . .
+ ./scripts/test
+ [[ ./scripts/test == \.\/\s\c\r\i\p\t\s\/\t\e\s\t ]]
+ [[ '' == \-\-\h\e\l\p ]]
+ docker run --rm quay.io/azavea/terraform:0.11.14 --version
Terraform v0.11.14

Your version of Terraform is out of date! The latest version
is 0.13.5. You can update by downloading from www.terraform.io/downloads.html
+ docker run --rm --entrypoint aws quay.io/azavea/terraform:0.11.14 --version
aws-cli/1.18.172 Python/3.6.9 Linux/5.8.13-arch1-1 botocore/1.19.12
+ docker images
REPOSITORY                   TAG                     IMAGE ID            CREATED              SIZE
quay.io/azavea/terraform     0.11.14                 928736006ffb        About a minute ago   255MB
```