### PR TITLE
Add Terraform 0.14.3 to build matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: ["0.11.11", "0.11.14", "0.12.2", "0.12.13", "0.12.29", "0.13.5"]
+        terraform_version:
+          [
+            "0.11.11",
+            "0.11.14",
+            "0.12.2",
+            "0.12.13",
+            "0.12.29",
+            "0.13.5",
+            "0.14.3",
+          ]
     env:
       DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ This repository contains a templated `Dockerfile` for image variants designed to
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 TERRAFORM_VERSION=0.13.5 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=0.14.3 ./scripts/cibuild
 ```


### PR DESCRIPTION
Builds container images for Terraform 0.14.3.

---

**Testing**

```console
$ CI=1 TERRAFORM_VERSION=0.14.3 ./scripts/cibuild
. . .
+ ./scripts/test
+ [[ ./scripts/test == \.\/\s\c\r\i\p\t\s\/\t\e\s\t ]]
+ [[ '' == \-\-\h\e\l\p ]]
+ docker run --rm quay.io/azavea/terraform:0.14.3 --version
Terraform v0.14.3
+ docker run --rm --entrypoint aws quay.io/azavea/terraform:0.14.3 --version
aws-cli/1.18.204 Python/3.8.5 Linux/5.8.13-arch1-1 botocore/1.19.44
+ docker images
REPOSITORY                                                         TAG                   IMAGE ID            CREATED             SIZE
quay.io/azavea/terraform                                           0.14.3                ad6e0f28c6b9        5 seconds ago       243MB
```